### PR TITLE
add rexml as dependency

### DIFF
--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rainbow', '~> 1.1'
   s.add_dependency 'thor', '~> 0.18'
   s.add_dependency 'yamllint', '~> 0.0.9'
+  s.add_dependency 'rexml'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec-expectations', '~> 3.5'


### PR DESCRIPTION
Required for ruby v3+ since rexml was moved from default to bundled gems in ruby 3.0.0. When someone tries to install stacker with ruby v3+, they get `...gems/aws-sdk-core-3.167.0/lib/aws-sdk-core/xml/parser.rb:74:in set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)`
https://stackoverflow.com/questions/69258788/aws-sdk-core-xml-parser-rb74in-set-default-engine-unable-to-find-a-compatib