### PR TITLE
Update jsonlint to 0.4.0

### DIFF
--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coderay', '~> 1.1'
   s.add_dependency 'diffy', '~> 3.0'
   s.add_dependency 'indentation', '~> 0.0'
-  s.add_dependency 'jsonlint', '~> 0.2.0'
+  s.add_dependency 'jsonlint', '~> 0.4.0'
   s.add_dependency 'memoist', '~> 0.14'
   s.add_dependency 'rainbow', '~> 1.1'
   s.add_dependency 'thor', '~> 0.18'


### PR DESCRIPTION
Seeing this error on a M2 Mac. Upgrading jsonlint to 0.4.0 seems to do the trick here so that it can successfully install

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/charles/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/oj-2.18.5/ext/oj
/Users/charles/.rbenv/versions/3.3.0/bin/ruby extconf.rb
>>>>> Creating Makefile for ruby version 3.3.0 on arm64-darwin23 <<<<<
creating Makefile

current directory: /Users/charles/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/oj-2.18.5/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20240328-27871-d0m0z1 sitelibdir\=./.gem.20240328-27871-d0m0z1 clean

current directory: /Users/charles/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/oj-2.18.5/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20240328-27871-d0m0z1 sitelibdir\=./.gem.20240328-27871-d0m0z1
compiling cache8.c
compiling circarray.c
compiling compat.c
compiling dump.c
dump.c:1067:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int
(*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_object, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/charles/.rbenv/versions/3.3.0/include/ruby-3.3.0/ruby/internal/intern/hash.h:83:40: note: passing argument to parameter 'func' here
void rb_hash_foreach(VALUE hash, int (*func)(VALUE key, VALUE val, VALUE arg), VALUE arg);
                                       ^
dump.c:1069:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int
(*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_compat, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/charles/.rbenv/versions/3.3.0/include/ruby-3.3.0/ruby/internal/intern/hash.h:83:40: note: passing argument to parameter 'func' here
void rb_hash_foreach(VALUE hash, int (*func)(VALUE key, VALUE val, VALUE arg), VALUE arg);
                                       ^
dump.c:1071:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int
(*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, hash_cb_strict, (VALUE)out);
                                 ^~~~~~~~~~~~~~
/Users/charles/.rbenv/versions/3.3.0/include/ruby-3.3.0/ruby/internal/intern/hash.h:83:40: note: passing argument to parameter 'func' here
void rb_hash_foreach(VALUE hash, int (*func)(VALUE key, VALUE val, VALUE arg), VALUE arg);
                                       ^
dump.c:1745:23: error: incompatible function pointer types passing 'int (ID, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int
(*)(ID, VALUE, st_data_t)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
        rb_ivar_foreach(obj, dump_attr_cb, (VALUE)out);
                             ^~~~~~~~~~~~
/Users/charles/.rbenv/versions/3.3.0/include/ruby-3.3.0/ruby/internal/intern/variable.h:263:39: note: passing argument to parameter 'func' here
void rb_ivar_foreach(VALUE obj, int (*func)(ID name, VALUE val, st_data_t arg), st_data_t arg);
                                      ^
4 errors generated.
make: *** [dump.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/charles/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/oj-2.18.5 for inspection.
Results logged to /Users/charles/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/extensions/arm64-darwin-23/3.3.0/oj-2.18.5/gem_make.out
```